### PR TITLE
V3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This script computes DMQC statistics for a given list of floats <br />
 **INPUTS**
  - **argo_profile_detailled_index.txt** and <br />
    **argo_synthetic-profile_detailled_index.txt** if i_BGC=1
- - **ar_greylist.txt**
+ - **argo_sensor_exclusion_list.txt**
  - **floats list**: csv file, separated by ";", with 4 fields:<br />
     WMO; COUNTRY; LAUNCH_DATE; PROGRAM<br />
         COUNTRY is the country in charge of the delayed mode processing (from OceanOPS)<br />
@@ -31,13 +31,18 @@ This script computes DMQC statistics for a given list of floats <br />
 <br />
 
  **CONFIGURATION PARAMETERS**
+ Since the V3.5 release, the configuration has been externalised within **get_DMQC_status_config.txt** file. Besides paths 
+ for the input files mentioned here-above, it allows to configure the following parameters:
  - **i_descending_profile**: 1 means descending profiles are considered, <br />
                          0 means descending profiles are not considered.
- - **sage**: threshold (in days) for floats and observations statistics.
+ - **profile_age_method** = 'date' or 'days': choose the method to filter "old" profiles
+ - **profile_age_min_days**: "old profiles" threshold (in days) for floats and observations statistics.
+ - **profile_age_max_date**: "old profiles" threshold (in date, format yyyy/mm/dd) for floats and observations statistics.
  - **i_bgc**: 1 means bgc profiles/parameters are considered (the detailed argo synthetic index will be <br />
             read for BGC parameters, the detailed argo index will be read for CTD)<br />
           0 means core information (CTD) is analysed from the detailed argo index.
- - **input_list_of_parameters_to_treat** is the list of parameters to analyse
+ - **input_list_of_parameters_to_treat** is the list of core parameters to analyse
+ - **input_list_of_BGC_parameters_to_treat** is the list of BGC parameters to analyse
  - **print_svg**: 1 means figures will be saved in .svg format as well<br />
  (interesting for high quality, but a little longer to save).
  - **output_graphs_per_float**: flag to indicate if graphs per float should be<br />
@@ -48,27 +53,26 @@ This script computes DMQC statistics for a given list of floats <br />
 <br />
 
 **OUTPUTS**
- - **Figures**   saved in folder outputs_yyyy-mm-dd_hhmmss/Plots 
- - **Analyses**  saved in folder outputs_yyyy-mm-dd_hhmmss/Syntheses 
- - **Copy of input files** saved in folder outputs_yyyy-mm-dd_hhmmss
+ - **Figures**   saved in folder output_files_yyyy-mm-dd_hhmmss/Plots 
+ - **Analyses**  saved in folder output_files_yyyy-mm-dd_hhmmss/Syntheses 
+ - **Copy of input files** saved in folder output_files_yyyy-mm-dd_hhmmss
 
  **Auxiliary functions needed**
   - read_csv
   - get_data_from_index 
   - plotBarStackGroups
   - grep (Matlab grep equivalent function)
+  - load_configuration.m
 
  **WARNING 1** : Profile_QC for PRES information is not yet available in the Argo detailed index. <br />
  It is filled with qc="X" in the script for the moment, and plots related to pres profile<br />
  qc are skipped.<br />
 
- **WARINING 2** : the detailed index has an issue with some psal adjustments 
- (not filled when it should). A correction was asked to the dev team. 
- In the meanwhile, plots with PSAL adjustment may not be complete.
+ **Nota Bene** : Profile_QC X means the profile contained no data.
 
  **Author**: Euro-Argo ERIC (contact@euro-argo.eu)<br />
 
- **Version**: 3.3 (2023/10/02)<br />
+ **Version**: 3.5 (2025/10/17)<br />
 
  **Historic**:<br />
  - V1.0 : This script was originally created by Andrea Garcia Juan and Romain<br />
@@ -116,7 +120,15 @@ This script computes DMQC statistics for a given list of floats <br />
    - 1-yr static string was replaced by the config value
    - add a new graph per profile year with DMQC and profile QC F + 
      output values in a text file
-   - add a log (diary) 
+   - add a log (diary)
+ - V3.5 (2025/10/17) :
+   - modify psal adj plot to separate RA mode not QC-F from RA mode QC-F profiles.
+   - correct cycles and descending profiles processing in get_data_from_index.m routine
+   - replace "grey list" by "exclusion list"
+   - correct issue with print('-dpng') for more recent Matlab versions, which do not support a space.
+   - externalise the configuration in a conf file
+   - choose the method to select old profiles/floats: either by profile age in days or by the profile date
+
 
 ## B. Graphical outputs for **get_DMQC_stats.m** 
 Different outputs are produced: graphical and textual. Here after are examples of graphical outputs obtained for floats from the MOCCA project.
@@ -266,3 +278,4 @@ Name & Description of the auxiliary functions:
 - get_data_from_index: gets chosen variables from index file for a given list of floats
 - plotBarStackGroups: Permit to make a bar plot with stacked bars for one graph tick.
 - grep : Matlab equivalent of the unix grep command (not as performant).
+- load_configuration: read the configuration file

--- a/scripts/aux_functions/get_data_from_index.m
+++ b/scripts/aux_functions/get_data_from_index.m
@@ -57,6 +57,8 @@ function [IndexData] = get_data_from_index(index_file, nb_header_lines,float_ref
 %        different lengths in WMO.
 % v3.3 (2023/09/01):
 %        - correct issue with parameter search: use of "(==)" instead of "contains" 
+% v3.5 (2025/10/15):
+%        - separate cycle from "D" in case of descending profiles.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%
@@ -126,8 +128,17 @@ clearvars tmp
 
 disp('---- Finding ascending and descending profiles and indexing relevant lines from the input file')
 % categorize ascending/desceding cycles
-% i_descending_cycles=contains(index_cycles,"D");
+i_descending_cycles=contains(RT_OUT_cycles,"D");
 i_ascending_cycles=~contains(RT_OUT_cycles,"D");
+RT_OUT_direction=RT_OUT_cycles;
+RT_OUT_direction(i_ascending_cycles)="A";
+RT_OUT_direction(i_descending_cycles)="D";
+
+
+% index_cycles bis
+% remove direction from cycle
+tmp=erase(RT_OUT_cycles,"D");
+RT_OUT_cycles=tmp;
 
 % subsetting the index information for lines concerning wmos provided in input 
 % and accounting for ascending or descending profiles option.
@@ -142,6 +153,7 @@ disp('---- Recording wmo, cycle number, date, lat, lon of relevant profiles')
 IndexData.profile_WMO = RT_OUT_wmos(i_relevant_index_lines);
 IndexData.profile_dac = RT_OUT_dacs(i_relevant_index_lines);
 IndexData.cycle       = RT_OUT_cycles(i_relevant_index_lines);
+IndexData.direction   = RT_OUT_direction(i_relevant_index_lines);
 IndexData.date        = RT_OUT(i_relevant_index_lines,ic_profile_date);
 IndexData.latitude    = RT_OUT(i_relevant_index_lines,ic_latitude);
 IndexData.longitude   = RT_OUT(i_relevant_index_lines,ic_longitude);

--- a/scripts/get_DMQC_status_config.txt
+++ b/scripts/get_DMQC_status_config.txt
@@ -1,0 +1,72 @@
+% ----------------------------------------------------------------------
+% ----------------------------------------------------------------------
+% DMQC status tool configuration
+% ----------------------------------------------------------------------
+% ----------------------------------------------------------------------
+
+
+% ----------------------------------------------------------------------
+% paths and files
+% ----------------------------------------------------------------------
+
+script_dir = /home1/datahome/co_arg/ddobler/04_DMQC/01_DMQC_Status/scripts/
+test_case_dir = /home1/datahome/co_arg/ddobler/04_DMQC/01_DMQC_Status/02_EuropeanFleet_case/
+
+%sub repository under test_case_dir containing wmo_list and country_code files
+input_file_dir = input_files
+wmo_list_file = wmo_list_to_process.txt
+country_code_file = country_codes.csv
+
+%sub repository prefix under test_case_dir containing all the tool outputs. 
+%this will be appended with the date and time the tool was run.
+output_file_dir_prefix = output_files
+log_file=matlab.log
+
+% index file dir. It can be set as the same as input_file_dir if index files are fetched
+% on the https or ftp access.
+index_file_dir = /home/ref-argo/gdac/etc/argo-index/
+index_file_core = argo_profile_detailled_index.txt
+index_file_bgc_synthetic = argo_synthetic-profile_detailled_index.txt
+
+% exclusion_file_dir. It must be fetched on the dmqc ftp (ask coriolis team for the access credentials)
+exclusion_file_dir = /home1/datahome/co_arg/ddobler/04_DMQC/01_DMQC_Status/common_input_files/
+exclusion_file = argo_sensor_exclusion_list.txt
+
+% ----------------------------------------------------------------------
+% comments on plots and syntheses 
+% ----------------------------------------------------------------------
+project_name = European_Fleet
+
+% -----------------------------------------------------------------------
+% computing and plotting features
+% -----------------------------------------------------------------------
+
+% list of core parameters to process (list separated by semicolon)
+input_list_of_parameters_to_treat=TEMP;PRES;PSAL
+
+% mention if BGC parameters should be processed and detail which parameters
+i_bgc=1
+input_list_of_BGC_parameters_to_treat=DOXY;CHLA;NITRATE;PH_IN_SITU_TOTAL;BBP700;DOWN_IRRADIANCE380
+% an example with the full list of possibilities:
+% input_list_of_BGC_parameters_to_treat=DOXY;DOXY2;CHLA;NITRATE;PH_IN_SITU_TOTAL;TURBIDITY;BISULFIDE;CDOM;BBP532;BBP700;DOWNWELLING_PAR;DOWN_IRRADIANCE380;DOWN_IRRADIANCE412;DOWN_IRRADIANCE443;DOWN_IRRADIANCE490;DOWN_IRRADIANCE555;DOWN_IRRADIANCE665;DOWN_IRRADIANCE670;CP660
+
+% include descending profiles ?
+i_descending_profile=1
+
+% to mention whether by-float information should be plotted and number of floats to be plotted on these by-float plots
+output_graphs_per_float=0
+n_max_float_per_graph=30
+
+% Select the method to consider old profiles: either with the profile_age_min_days (days) or with profile_age_max_date (date)
+profile_age_method=days
+% Number of days for "old" profiles
+profile_age_min_days=720
+% Date threshold for "old" profiles
+profile_age_max_date=2023/01/01
+
+%additional format for output plots
+print_svg=0
+
+% to group profile_qc A and B in computations and plots.
+i_group_AB_profQC=1
+

--- a/scripts/load_configuration.m
+++ b/scripts/load_configuration.m
@@ -1,0 +1,53 @@
+
+function [ pt_input_parameters ] = load_configuration( ps_filename )
+
+%
+% loadConfiguration
+%
+% loadConfiguration loads a set of properties from a file
+% and returns the results in a structure variable. This routine 
+% copied from OWC tool.
+%
+% The file is formatted as value pairs (one line per value):
+%
+%    key_name=key_value
+%
+% Also, any line starting with a '%' will be ignored.
+%
+% Note: all values of key_name must be valid matlab
+%       variable names.
+%
+%       In the case of duplicate entries, the last key
+%       to appear in the file will override previous
+%       definitions.
+%
+%       Invalid lines are disregarded.
+%
+%  Jason Fabritz, 2001
+%
+
+lh_file = fopen( ps_filename ) ;
+
+pt_input_parameters = struct('conf', ps_filename ) ;
+
+while not(feof(lh_file)) 
+    ls_line = fgetl(lh_file);
+    ls_line(strfind(ls_line, ' ')) = [];
+    if ~isempty(ls_line)
+        if ls_line(1:1) ~= '%'
+        ln_equals_index = strfind(ls_line, '=');
+            if ~isempty(ln_equals_index)
+                if ln_equals_index(1) > 1
+                    sKey   = ls_line(1:ln_equals_index(1) - 1);
+                    sValue = ls_line(ln_equals_index(1) + 1:length(ls_line));
+                    pt_input_parameters.(sKey)=sValue;
+                end
+            end
+        end
+    end   
+end
+
+fclose( lh_file ) ;
+
+return
+


### PR DESCRIPTION
Release V3.5:
- modify psal adjustmant plots to separate RA mode not QC-F from RA mode QC-F profiles.
- correct cycles and descending profiles processing in get_data_from_index.m routine (was affecting by-wmo plots)
- replace "grey list" by "exclusion list"
- correct issue with print('-dpng') for more recent Matlab versions, which do not support a space (issue #8 part a)
- externalise the configuration in a conf file (close issue #9)
- choose the method to select old profiles/floats: either by profile age in days or by the profile date (requirement for backlog analysis reproducibilty)

N.B.: missing profile_qc refers to a missing profile data (issue #8 part b)
